### PR TITLE
rm enum for output spaces, 1.5.9 [GEAR-183] [GEAR-235]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM poldracklab/fmriprep:1.5.8
+FROM poldracklab/fmriprep:1.5.9
 
 MAINTAINER Flywheel <support@flywheel.io>
 
@@ -13,7 +13,7 @@ RUN apt-get update && \
 
 RUN npm install -g bids-validator@1.4.0
 
-RUN pip install flywheel-sdk==10.7.1 \
+RUN pip install flywheel-sdk==11.2.3 \
         flywheel-bids==0.8.2 \
         psutil==5.6.3 && \
     rm -rf /root/.cache/pip

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,12 @@
   "name": "bids-fmriprep",
   "label": "BIDS fMRIPrep: A Robust Preprocessing Pipeline for fMRI Data",
   "description": "fMRIPrep (1.5.8 January 28, 2020) is a functional magnetic resonance imaging (fMRI) data preprocessing pipeline that is designed to provide an easily accessible, state-of-the-art interface that is robust to variations in scan acquisition protocols and that requires minimal user input, while providing easily interpretable and comprehensive error and output reporting. It performs basic processing steps (coregistration, normalization, unwarping, noise component extraction, segmentation, skullstripping etc.) providing outputs that can be easily submitted to a variety of group level analyses, including task-based or resting-state fMRI, graph theory measures, surface or volume-based statistics, etc.",
-  "version": "1.0.7_1.5.9",
+  "version": "1.0.8_1.5.9",
   "custom": {
-    "docker-image": "flywheel/bids-fmriprep:1.0.7_1.5.9",
+    "docker-image": "flywheel/bids-fmriprep:1.0.8_1.5.9",
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/bids-fmriprep:1.0.7_1.5.9"
+      "image": "flywheel/bids-fmriprep:1.0.8_1.5.9"
     },
     "flywheel": {
       "suite": "BIDS Apps"
@@ -122,7 +122,7 @@
     },
     "output-spaces": {
       "description": "Standard and non-standard spaces to resample anatomical and functional images to. Standard spaces may be specified by the form <TEMPLATE>[:res-<resolution>][:cohort-<label>][...], where <TEMPLATE> is a keyword (valid keywords: “MNI152Lin”, “MNI152NLin2009cAsym”, “MNI152NLin6Asym”, “MNI152NLin6Sym”, “MNIInfant”, “MNIPediatricAsym”, “NKI”, “OASIS30ANTs”, “PNC”, “fsLR”, “fsaverage”) or path pointing to a user-supplied template, and may be followed by optional, colon-separated parameters. Non-standard spaces (valid keywords: anat, T1w, run, func, sbref, fsnative) imply specific orientations and sampling grids. Important to note, the res-* modifier does not define the resolution used for the spatial normalization. For further details, please check out https://fmriprep.readthedocs.io/en/stable/spaces.html",
-      "optional": true,
+      "default": "MNI152NLin2009cAsym",
       "type": "string"
     },
     "bold2t1w-dof": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,12 @@
   "name": "bids-fmriprep",
   "label": "BIDS fMRIPrep: A Robust Preprocessing Pipeline for fMRI Data",
   "description": "fMRIPrep (1.5.8 January 28, 2020) is a functional magnetic resonance imaging (fMRI) data preprocessing pipeline that is designed to provide an easily accessible, state-of-the-art interface that is robust to variations in scan acquisition protocols and that requires minimal user input, while providing easily interpretable and comprehensive error and output reporting. It performs basic processing steps (coregistration, normalization, unwarping, noise component extraction, segmentation, skullstripping etc.) providing outputs that can be easily submitted to a variety of group level analyses, including task-based or resting-state fMRI, graph theory measures, surface or volume-based statistics, etc.",
-  "version": "1.0.6_1.5.8",
+  "version": "1.0.7_1.5.9",
   "custom": {
-    "docker-image": "flywheel/bids-fmriprep:1.0.6_1.5.8",
+    "docker-image": "flywheel/bids-fmriprep:1.0.7_1.5.9",
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/bids-fmriprep:1.0.6_1.5.8"
+      "image": "flywheel/bids-fmriprep:1.0.7_1.5.9"
     },
     "flywheel": {
       "suite": "BIDS Apps"
@@ -122,20 +122,6 @@
     },
     "output-spaces": {
       "description": "Standard and non-standard spaces to resample anatomical and functional images to. Standard spaces may be specified by the form <TEMPLATE>[:res-<resolution>][:cohort-<label>][...], where <TEMPLATE> is a keyword (valid keywords: “MNI152Lin”, “MNI152NLin2009cAsym”, “MNI152NLin6Asym”, “MNI152NLin6Sym”, “MNIInfant”, “MNIPediatricAsym”, “NKI”, “OASIS30ANTs”, “PNC”, “fsLR”, “fsaverage”) or path pointing to a user-supplied template, and may be followed by optional, colon-separated parameters. Non-standard spaces (valid keywords: anat, T1w, run, func, sbref, fsnative) imply specific orientations and sampling grids. Important to note, the res-* modifier does not define the resolution used for the spatial normalization. For further details, please check out https://fmriprep.readthedocs.io/en/stable/spaces.html",
-      "enum": [
-        "",
-        "MNI152Lin",
-        "MNI152NLin2009cAsym",
-        "MNI152NLin6Asym",
-        "MNI152NLin6Sym",
-        "MNIInfant",
-        "MNIPediatricAsym",
-        "NKI",
-        "OASIS30ANTs",
-        "PNC",
-        "fsLR",
-        "fsaverage"
-      ],
       "optional": true,
       "type": "string"
     },


### PR DESCRIPTION
"Output spaces" in manifest was limiting what could be done by using setting the choices with enum.  Removing that lets multiple output spaces to be used.

This also bumps up the version to 1.5.9, even though there is a more recent version (and my commit description said "1.5.8" oops).

Related: [https://flywheelio.atlassian.net/browse/GEAR-183](https://flywheelio.atlassian.net/browse/GEAR-183)

Related: [https://flywheelio.atlassian.net/browse/GEAR-235](https://flywheelio.atlassian.net/browse/GEAR-235)