### PR TITLE
GEAR-1996 comment out templateflow env vars

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -303,13 +303,13 @@
     }
   },
   "custom": {
-    "docker-image": "flywheel/bids-fmriprep:1.2.3_20.2.6",
+    "docker-image": "flywheel/bids-fmriprep:1.2.4_20.2.6",
     "flywheel": {
       "suite": "BIDS Apps"
     },
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/bids-fmriprep:1.2.3_20.2.6"
+      "image": "flywheel/bids-fmriprep:1.2.4_20.2.6"
     },
     "license": {
       "dependencies": [
@@ -383,5 +383,5 @@
   "name": "bids-fmriprep",
   "source": "https://github.com/nipreps/fmriprep",
   "url": "https://github.com/flywheel-apps/bids-fmriprep/blob/master/README.md",
-  "version": "1.2.3_20.2.6"
+  "version": "1.2.4_20.2.6"
 }

--- a/run.py
+++ b/run.py
@@ -283,10 +283,11 @@ def main(gtk_context):
         FREESURFER_LICENSE,
     )
 
-    templateflow_dir = FWV0 / "templateflow"
-    templateflow_dir.mkdir()
-    environ["SINGULARITYENV_TEMPLATEFLOW_HOME"] = str(templateflow_dir)
-    environ["TEMPLATEFLOW_HOME"] = str(templateflow_dir)
+    # TemplateFlow seems to be baked in to the container since 2021-10-07 16:25:12 so this is not needed
+    # templateflow_dir = FWV0 / "templateflow"
+    # templateflow_dir.mkdir()
+    # environ["SINGULARITYENV_TEMPLATEFLOW_HOME"] = str(templateflow_dir)
+    # environ["TEMPLATEFLOW_HOME"] = str(templateflow_dir)
 
     command = generate_command(
         config, work_dir, output_analysis_id_dir, errors, warnings

--- a/tests/integration_tests/test_fake_data_timeout.py
+++ b/tests/integration_tests/test_fake_data_timeout.py
@@ -44,5 +44,5 @@ def test_fake_data_killed(
 
         assert "freesurfer/license.txt" in toml_info["execution"]["fs_license_file"]
 
-        assert toml_info["execution"]["templateflow_home"] == str(FWV0 / "templateflow")
+        # assert toml_info["execution"]["templateflow_home"] == str(FWV0 / "templateflow")
         assert search_caplog(caplog, "Unable to execute command")


### PR DESCRIPTION
It turns out that the fMRIPrep BIDS App recently started baking in the TemplateFlow templates so adding that as an input is not necessary and switching to a writeable directory for TEMPLATEFLOW_HOME and SINGULARITYENV_TEMPLATEFLOW_HOME are also no longer needed.

The old code was commented out instead of deleted because it may be necessary someday if somebody wants to use a different template.  This might be needed when running under Singularity because the code won't have write access to the default location.