### PR TITLE
No tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ to provide the license to this gear.  A license is required for this gear to run
 ### fs-subjects-dir (optional)
 Zip file of existing FreeSurfer subject's directory to reuse.  If the output of FreeSurfer recon-all is provided to fMRIPrep, that output will be used rather than re-running recon-all.  Unzipping the file should produce a particular subject's directory which will be placed in the $FREESURFER_HOME/subjects directory.  The name of the directory must match the -subjid as passed to recon-all.  This version of fMRIPrep uses Freesurfer v6.0.1.
 
+### previous-results (optional)
+Provide previously calculated fMRIPrep output results zip file as in input.  This file will be unzipped into the output directory so that previous results will be used instead of re-calculating them.  This input is provided so that bids-fmriprep can be run incrementally as new data is acquired.
+
 ### work-dir (optional)
 THIS IS A FUTURE OPTIONAL INPUT.  It has not yet been added.  Provide intermediate fMRIPrep results as a zip file.  This file will be unzipped into the work directory so that previous results will be used instead of re-calculating them.  This option is provided so that bids-fmriprep can be run incrementally as new data is acquired.  The zip file to provide can be produced by using the gear-save-intermediate-output configuration option.  You definitely also want to use the fs-subject-dir input (above) so that FreeSurfer won't be run multiple times.
 

--- a/manifest.json
+++ b/manifest.json
@@ -308,13 +308,13 @@
     }
   },
   "custom": {
-    "docker-image": "flywheel/bids-fmriprep:1.2.6_20.2.6",
+    "docker-image": "flywheel/bids-fmriprep:1.2.8_20.2.6",
     "flywheel": {
       "suite": "BIDS Apps"
     },
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/bids-fmriprep:1.2.6_20.2.6"
+      "image": "flywheel/bids-fmriprep:1.2.8_20.2.6"
     },
     "license": {
       "dependencies": [
@@ -388,5 +388,5 @@
   "name": "bids-fmriprep",
   "source": "https://github.com/nipreps/fmriprep",
   "url": "https://github.com/flywheel-apps/bids-fmriprep/blob/master/README.md",
-  "version": "1.2.6_20.2.6"
+  "version": "1.2.8_20.2.6"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -156,6 +156,11 @@
       "description": "Gear will save ALL intermediate output into fmriprep_work_*.zip",
       "type": "boolean"
     },
+    "gear-writable-dir": {
+      "default": "/var/tmp",
+      "description": "Gears expect to be able to write temporary files in /flywheel/v0/.  If this location is not writable (such as when running in Singularity), this path will be used instead.  fMRIPrep creates a large number of files so this disk space should be fast and local.",
+      "type": "string"
+    },
     "ignore": {
       "default": "",
       "description": "Ignore selected aspects of the input dataset to disable corresponding parts of the workflow (a space delimited list)  Possible choices: fieldmaps, slicetiming, sbref",
@@ -303,13 +308,13 @@
     }
   },
   "custom": {
-    "docker-image": "flywheel/bids-fmriprep:1.2.4_20.2.6",
+    "docker-image": "flywheel/bids-fmriprep:1.2.5_20.2.6",
     "flywheel": {
       "suite": "BIDS Apps"
     },
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/bids-fmriprep:1.2.4_20.2.6"
+      "image": "flywheel/bids-fmriprep:1.2.5_20.2.6"
     },
     "license": {
       "dependencies": [
@@ -383,5 +388,5 @@
   "name": "bids-fmriprep",
   "source": "https://github.com/nipreps/fmriprep",
   "url": "https://github.com/flywheel-apps/bids-fmriprep/blob/master/README.md",
-  "version": "1.2.4_20.2.6"
+  "version": "1.2.5_20.2.6"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -308,13 +308,13 @@
     }
   },
   "custom": {
-    "docker-image": "flywheel/bids-fmriprep:1.2.5_20.2.6",
+    "docker-image": "flywheel/bids-fmriprep:1.2.6_20.2.6",
     "flywheel": {
       "suite": "BIDS Apps"
     },
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/bids-fmriprep:1.2.5_20.2.6"
+      "image": "flywheel/bids-fmriprep:1.2.6_20.2.6"
     },
     "license": {
       "dependencies": [
@@ -388,5 +388,5 @@
   "name": "bids-fmriprep",
   "source": "https://github.com/nipreps/fmriprep",
   "url": "https://github.com/flywheel-apps/bids-fmriprep/blob/master/README.md",
-  "version": "1.2.5_20.2.6"
+  "version": "1.2.6_20.2.6"
 }

--- a/run.py
+++ b/run.py
@@ -240,7 +240,8 @@ def main(gtk_context):
     # Fill writable templateflow directory with existing templates so they don't have to be downloaded
     templates = list(orig.glob("*"))
     for tt in templates:
-        (templateflow_dir / tt.name).symlink_to(tt)
+        # (templateflow_dir / tt.name).symlink_to(tt)
+        shutil.copytree(tt, templateflow_dir / tt.name)
 
     command = generate_command(
         config, work_dir, output_analysis_id_dir, errors, warnings
@@ -270,10 +271,6 @@ def main(gtk_context):
         log.info("Did not download BIDS because of previous errors")
         print(errors)
 
-    if config["gear-log-level"] != "INFO":
-        # show what's in the current working directory just before running
-        os.system("tree -al .")
-
     return_code = 0
     num_tries = 0
 
@@ -301,6 +298,10 @@ def main(gtk_context):
 
                 if "gear-timeout" in config:
                     command = [f"timeout {config['gear-timeout']}"] + command
+
+                if config["gear-log-level"] != "INFO":
+                    # show what's in the current working directory just before running
+                    os.system("tree -alh .")
 
                 # This is what it is all about
                 exec_command(
@@ -340,6 +341,11 @@ def main(gtk_context):
             log.info(f"Wrote {output_dir}/.metadata.json")
 
     # Cleanup, move all results to the output directory
+
+    if return_code != 0:
+        os.system("echo ")
+        os.system("echo Disk Information on Failure")
+        os.system("df -h")
 
     # Remove all fsaverage* directories
     if not config.get("gear-keep-fsaverage"):

--- a/run.py
+++ b/run.py
@@ -236,6 +236,11 @@ def main(gtk_context):
     templateflow_dir.mkdir()
     environ["SINGULARITYENV_TEMPLATEFLOW_HOME"] = str(templateflow_dir)
     environ["TEMPLATEFLOW_HOME"] = str(templateflow_dir)
+    orig = Path("/home/fmriprep/.cache/templateflow/")
+    # Fill writable templateflow directory with existing templates so they don't have to be downloaded
+    templates = list(orig.glob("*"))
+    for tt in templates:
+        (templateflow_dir / tt.name).symlink_to(tt)
 
     command = generate_command(
         config, work_dir, output_analysis_id_dir, errors, warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from flywheel_gear_toolkit.utils.zip_tools import unzip_archive
 
 from utils.singularity import run_in_tmp_dir
 
-run_in_tmp_dir()  # run all tests in /tmp/*/flywheel/v0 where * is random
+run_in_tmp_dir("/var/tmp")  # run all tests in /tmp/*/flywheel/v0 where * is random
 
 FWV0 = Path.cwd()
 

--- a/tests/integration_tests/test_dry_run.py
+++ b/tests/integration_tests/test_dry_run.py
@@ -42,27 +42,6 @@ def test_dry_run_works(
             "command is",
             "--bids-filter-file=input/bids-filter-file/PyBIDS_filter.json",
         )
-        assert search_caplog_contains(
-            caplog, "--work-dir", "flywheel/v0/output/61608fc7dbf5f9487f231006"
-        )
-
-        # Since the "work-dir" option was used, the gear created the old data's /tmp/ path and
-        # ran in it, and a symbolic link was created from the current /tmp/ path to the old one.
-        # The "current" path was created just before these tests started (in conftest.py). E.g.:
-        # % ls /tmp
-        # gear-temp-dir-2cde80oy -> /tmp/gear-temp-dir-yhv7hq29
-        # gear-temp-dir-yhv7hq29
-        # where "yhv7hq29" is the old random part found in the provided "work-dir" data and
-        # "2cde80oy" is the new random part of the /tmp/ path created to run these tests.
-        # The new part is generated randomly so it will change but the old one is in the gear test
-        # data provided as an input to the gear.
-        old_tmp_path = Path(*(list(Path.cwd().parts)[:3]))
-        assert "yhv7hq29" in list(old_tmp_path.parts)[2]
-        current_tmp_path = Path(*(list(FWV0.parts)[:3]))
-        assert current_tmp_path.is_symlink()
-        # now change back to the original /tmp/ path so that following tests will not be affected
-        current_tmp_path.unlink()
-        old_tmp_path.replace(current_tmp_path)
 
         assert search_caplog_contains(caplog, "command is", "participant")
         assert search_caplog_contains(caplog, "command is", "'arg1', 'arg2'")

--- a/tests/integration_tests/test_fake_data_timeout.py
+++ b/tests/integration_tests/test_fake_data_timeout.py
@@ -30,7 +30,13 @@ def test_fake_data_killed(
 
     with flywheel_gear_toolkit.GearToolkitContext(input_args=[]) as gtk_context:
 
+        Path("/home/fmriprep/.cache/templateflow/").chmod(0o555)
+
         status = run.main(gtk_context)
+
+        assert Path(
+            "/flywheel/v0/templateflow/tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-02_label-WM_probseg.nii.gz"
+        ).exists()
 
         toml_file = list(FWV0.glob("work/*/config.toml"))[0]
         assert toml_file.exists()

--- a/tests/integration_tests/test_fake_data_timeout.py
+++ b/tests/integration_tests/test_fake_data_timeout.py
@@ -52,3 +52,6 @@ def test_fake_data_killed(
 
         # assert toml_info["execution"]["templateflow_home"] == str(FWV0 / "templateflow")
         assert search_caplog(caplog, "Unable to execute command")
+        assert search_caplog(
+            caplog, "Sadly, fMRIPrep did not work on the first or second try"
+        )

--- a/tests/integration_tests/test_fake_data_timeout.py
+++ b/tests/integration_tests/test_fake_data_timeout.py
@@ -36,7 +36,16 @@ def test_fake_data_killed(
 
         assert Path(
             "/flywheel/v0/templateflow/tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-02_label-WM_probseg.nii.gz"
-        ).exists()
+        ).is_file()
+
+        assert (
+            Path(
+                "/flywheel/v0/templateflow/tpl-OASIS30ANTs/tpl-OASIS30ANTs_res-01_label-WM_probseg.nii.gz"
+            )
+            .stat()
+            .st_size
+            != 0
+        )
 
         toml_file = list(FWV0.glob("work/*/config.toml"))[0]
         assert toml_file.exists()

--- a/tests/unit_tests/test_download_run_level.py
+++ b/tests/unit_tests/test_download_run_level.py
@@ -103,7 +103,7 @@ class Acquisition:
         self.label = "TheAcquisitionLabel"
 
 
-def test_download_bids_for_runlevel_acquisition_works(tmp_path, caplog):
+def test_download_bids_for_runlevel_acquisition_works(tmp_path, search_caplog, caplog):
 
     caplog.set_level(logging.DEBUG)
 
@@ -137,8 +137,7 @@ def test_download_bids_for_runlevel_acquisition_works(tmp_path, caplog):
                     dry_run=False,
                 )
 
-    assert len(caplog.records) == 10
-    assert "Downloading BIDS data was successful" in caplog.records[9].message
+    assert search_caplog(caplog, "Downloading BIDS data was successful")
 
 
 def test_download_bids_for_runlevel_no_destination_complains(tmp_path, caplog):
@@ -171,7 +170,6 @@ def test_download_bids_for_runlevel_no_destination_complains(tmp_path, caplog):
                     dry_run=True,
                 )
 
-    assert len(caplog.records) == 2
     assert "Destination does not exist" in caplog.records[0].message
 
     HIERARCHY["run_level"] = "acquisition"  # fix what was broke

--- a/tests/unit_tests/test_download_run_level.py
+++ b/tests/unit_tests/test_download_run_level.py
@@ -137,8 +137,8 @@ def test_download_bids_for_runlevel_acquisition_works(tmp_path, caplog):
                     dry_run=False,
                 )
 
-    assert len(caplog.records) == 9
-    assert "Downloading BIDS data was successful" in caplog.records[8].message
+    assert len(caplog.records) == 10
+    assert "Downloading BIDS data was successful" in caplog.records[9].message
 
 
 def test_download_bids_for_runlevel_no_destination_complains(tmp_path, caplog):
@@ -178,7 +178,9 @@ def test_download_bids_for_runlevel_no_destination_complains(tmp_path, caplog):
     HIERARCHY["run_label"] = HIERARCHY[f"{HIERARCHY['run_level']}_label"]
 
 
-def test_download_bids_for_runlevel_bad_destination_noted(tmp_path, caplog):
+def test_download_bids_for_runlevel_bad_destination_noted(
+    tmp_path, caplog, search_caplog
+):
 
     caplog.set_level(logging.DEBUG)
 
@@ -218,15 +220,16 @@ def test_download_bids_for_runlevel_bad_destination_noted(tmp_path, caplog):
                     dry_run=True,
                 )
 
-    assert len(caplog.records) == 9
-    assert "is not an analysis or acquisition" in caplog.records[0].message
-    assert 'subject "TheSubjectCode"' in caplog.records[4].message
+    assert search_caplog(caplog, "is not an analysis or acquisition")
+    assert search_caplog(caplog, 'subject "TheSubjectCode"')
 
     HIERARCHY["run_level"] = "acquisition"  # fix what was broke
     HIERARCHY["run_label"] = HIERARCHY[f"{HIERARCHY['run_level']}_label"]
 
 
-def test_download_bids_for_runlevel_unknown_acquisition_detected(tmp_path, caplog):
+def test_download_bids_for_runlevel_unknown_acquisition_detected(
+    tmp_path, caplog, search_caplog
+):
 
     caplog.set_level(logging.DEBUG)
 
@@ -266,11 +269,10 @@ def test_download_bids_for_runlevel_unknown_acquisition_detected(tmp_path, caplo
                     dry_run=True,
                 )
 
-    assert len(caplog.records) == 5
-    assert 'acquisition "unknown acquisition"' in caplog.records[3].message
+    assert search_caplog(caplog, 'acquisition "unknown acquisition"')
 
 
-def test_download_bids_for_runlevel_session_works(tmp_path, caplog):
+def test_download_bids_for_runlevel_session_works(tmp_path, caplog, search_caplog):
 
     caplog.set_level(logging.DEBUG)
 
@@ -310,14 +312,15 @@ def test_download_bids_for_runlevel_session_works(tmp_path, caplog):
                     dry_run=True,
                 )
 
-    assert len(caplog.records) == 8
-    assert 'session "TheSessionLabel"' in caplog.records[3].message
+    assert search_caplog(caplog, 'session "TheSessionLabel"')
 
     HIERARCHY["run_level"] = "acquisition"  # fix what was broke
     HIERARCHY["run_label"] = HIERARCHY[f"{HIERARCHY['run_level']}_label"]
 
 
-def test_download_bids_for_runlevel_acquisition_exception_detected(tmp_path, caplog):
+def test_download_bids_for_runlevel_acquisition_exception_detected(
+    tmp_path, caplog, search_caplog
+):
 
     caplog.set_level(logging.DEBUG)
 
@@ -348,11 +351,10 @@ def test_download_bids_for_runlevel_acquisition_exception_detected(tmp_path, cap
                     dry_run=True,
                 )
 
-    assert len(caplog.records) == 6
-    assert "(foo) Reason: fum" in caplog.records[4].message
+    assert search_caplog(caplog, "(foo) Reason: fum")
 
 
-def test_download_bids_for_runlevel_unknown_detected(tmp_path, caplog):
+def test_download_bids_for_runlevel_unknown_detected(tmp_path, caplog, search_caplog):
 
     caplog.set_level(logging.DEBUG)
 
@@ -386,15 +388,14 @@ def test_download_bids_for_runlevel_unknown_detected(tmp_path, caplog):
                 dry_run=True,
             )
 
-    assert len(caplog.records) == 5
-    assert "run_level = who knows" in caplog.records[3].message
+    assert search_caplog(caplog, "run_level = who knows")
 
     HIERARCHY["run_level"] = "acquisition"  # fix what was broke
     HIERARCHY["run_label"] = HIERARCHY[f"{HIERARCHY['run_level']}_label"]
 
 
 def test_download_bids_for_runlevel_bidsexporterror_exception_detected(
-    tmp_path, caplog
+    tmp_path, caplog, search_caplog
 ):
 
     caplog.set_level(logging.DEBUG)
@@ -426,11 +427,12 @@ def test_download_bids_for_runlevel_bidsexporterror_exception_detected(
                     dry_run=True,
                 )
 
-    assert len(caplog.records) == 6
-    assert "crash" in caplog.records[4].message
+    assert search_caplog(caplog, "crash")
 
 
-def test_download_bids_for_runlevel_validate_exception_detected(tmp_path, caplog):
+def test_download_bids_for_runlevel_validate_exception_detected(
+    tmp_path, caplog, search_caplog
+):
 
     caplog.set_level(logging.DEBUG)
 
@@ -470,14 +472,15 @@ def test_download_bids_for_runlevel_validate_exception_detected(tmp_path, caplog
                     dry_run=True,
                 )
 
-    assert len(caplog.records) == 9
-    assert "('except', 'what')" in caplog.records[7].message
+    assert search_caplog(caplog, "('except', 'what')")
 
     HIERARCHY["run_level"] = "acquisition"  # fix what was broke
     HIERARCHY["run_label"] = HIERARCHY[f"{HIERARCHY['run_level']}_label"]
 
 
-def test_download_bids_for_runlevel_nothing_downloaded_detected(tmp_path, caplog):
+def test_download_bids_for_runlevel_nothing_downloaded_detected(
+    tmp_path, caplog, search_caplog
+):
 
     caplog.set_level(logging.DEBUG)
 
@@ -506,13 +509,7 @@ def test_download_bids_for_runlevel_nothing_downloaded_detected(tmp_path, caplog
                 dry_run=True,
             )
 
-    assert len(caplog.records) == 6
-    assert "No BIDS data was found" in caplog.records[4].message
+    assert search_caplog(caplog, "No BIDS data was found")
 
     HIERARCHY["run_level"] = "acquisition"  # fix what was broke
     HIERARCHY["run_label"] = HIERARCHY[f"{HIERARCHY['run_level']}_label"]
-
-
-if __name__ == "__main__":
-
-    test_download_bids_for_runlevel_project_works("/tmp", None)

--- a/tests/unit_tests/test_environment.py
+++ b/tests/unit_tests/test_environment.py
@@ -14,4 +14,6 @@ def test_get_and_log_environment_works(caplog, search_caplog):
     assert environ["FLYWHEEL"] == "/flywheel/v0"
     assert environ["FREESURFER_HOME"] == "/opt/freesurfer"
     assert search_caplog(caplog, "FREESURFER_HOME=/opt/freesurfer")
-    assert search_caplog(caplog, "Grabbing environment from /tmp/gear-temp-dir-")
+    assert search_caplog(
+        caplog, "Grabbing environment from /flywheel/v0/gear_environ.json"
+    )


### PR DESCRIPTION
- no longer runs in /tmp unless /flywheel/v0 is not writable.  In that case, runs in directory provided by new config option `gear-writable-dir` which must be set when running in Singularity.
- copies templateflow templates from default location to where the gear is running which is now guaranteed to be a writable directory even when running in Singularity.  This is necessary for when templates need to be downloaded.  Original attempt was to just link to the default templates, but that caused fMRIPrep to make templates zero length.
- now re-tries running fMRIPrep on first failure
- added some extra debugging output
-  updated a bunch of tests